### PR TITLE
ADD scripts to verify two forms of supcon

### DIFF
--- a/sanity_checks/README.md
+++ b/sanity_checks/README.md
@@ -1,0 +1,49 @@
+There are two possible ways to write the SupCon loss:
+
+We chose a different way to write the SupCon loss so that differences with our proposed loss would be more clear. However, the two forms of SupCon are equivalent, as we explain below.
+
+Here, we provide a side-by-side comparison of the original SupCon loss and our formulation of it: 
+
+$$
+\sum_i \sum_{p} L^{theirs}( i, p), ~~L^{theirs}( i, p) &= \frac{-1}{|\mathcal{P}(i)|} \log \frac{ e^{z_i \cdot z_p} }{ e^{z_i \cdot z_p} + \sum_{q \in \mathcal{P}(i) \setminus p} e^{z_i \cdot z_q} + \sum_{n \in \mathcal{N}(i)} e^{z_i \cdot z_n} }
+\\
+\sum_S \sum_{p} L^{ours}( S, p), ~~L^{ours}( S, p) &= \frac{-1}{|\mathcal{P}(S)|} \log \frac{ e^{z_p \cdot z_S} }{ e^{z_p \cdot z_S} + \sum_{q \in \mathcal{P}(S) \setminus p} e^{z_p \cdot z_q} + \sum_{n \in \mathcal{N}(S)} e^{z_p \cdot z_n} }
+$$
+
+
+Consider the top line as a translation of Khosla et al’s Eq 2 into our notation. Consider the bottom line as equivalent to our submission’s Eq 3, with minor adjustments for clarity (e.g. written as a function of two indices of the current batch). For notational simplicity, both lines above assume a fixed temperature of $$\tau = 1$$.
+
+As a reminder of notation:
+the target integer index is “S” in our notation (“i” in Khosla et al), and ranges from {1, 2, … batch_size}
+the partner integer index “p” has the same meaning in both lines: another image in the batch with the same label as the target index. The set of possible partners of the same class for index $$S$$ is denoted as $$\mathcal{P}(S)$$
+If (S,p) is a valid input to either loss above, we can guarantee that (p, S) is also a valid input, because p is an index in the current batch, and S is another image in the batch that shares the same class label.
+
+At a quick glance, the two formulations do look distinct, as the top one uses the target index “i” in all terms in the denominator, while the bottom uses the partner index “p”.
+
+
+However, what really matters is whether the total sum over all pairs of target and partner index is the same. In fact, the total sum of both forms above can be shown to be exactly equivalent. For every $$S,p$$ index pair aggregated in our version (the bottom sum), there is an equivalent term in the top sum, because $$L^{ours}(S,p) = L^{theirs}(p, S)$$, a fact easily verified by inspection.
+
+
+# Script to verify the two forms are equivalent
+
+We have included the script `check_two_forms_of_supcon.py` in our anonymous code repo. This script shows that for a concrete minibatch of embeddings, the two versions of the loss deliver the same numerical answer.
+
+Here’s an example output for a batch of 6 synthetically generated embedding vectors, where the first 3 indices belong to class0 and the last 3 indices belong to class1. The same total loss value is produced by the two formulations, “ours” and “theirs”:
+
+S= 0 p= 1  | L^ours(S,p) = -1.1122  | L^theirs(p, S) =-1.1122
+S= 0 p= 2  | L^ours(S,p) = -0.0364  | L^theirs(p, S) =-0.0364
+S= 1 p= 0  | L^ours(S,p) = -0.8681  | L^theirs(p, S) =-0.8681
+S= 1 p= 2  | L^ours(S,p) = -2.0168  | L^theirs(p, S) =-2.0168
+S= 2 p= 0  | L^ours(S,p) = -0.1271  | L^theirs(p, S) =-0.1271
+S= 2 p= 1  | L^ours(S,p) = -2.3515  | L^theirs(p, S) =-2.3515
+S= 3 p= 4  | L^ours(S,p) = -1.0308  | L^theirs(p, S) =-1.0308
+S= 3 p= 5  | L^ours(S,p) = -0.5278  | L^theirs(p, S) =-0.5278
+S= 4 p= 3  | L^ours(S,p) = -2.5750  | L^theirs(p, S) =-2.5750
+S= 4 p= 5  | L^ours(S,p) = -1.2277  | L^theirs(p, S) =-1.2277
+S= 5 p= 3  | L^ours(S,p) = -1.2569  | L^theirs(p, S) =-1.2569
+S= 5 p= 4  | L^ours(S,p) = -0.4125  | L^theirs(p, S) =-0.4125
+
+Total sum over all (S,p) pairs:
+ -13.5427 ours
+ -13.5427 theirs
+

--- a/sanity_checks/check_two_forms_of_supcon.py
+++ b/sanity_checks/check_two_forms_of_supcon.py
@@ -1,0 +1,120 @@
+import numpy as np
+from scipy.special import logsumexp
+import copy
+
+def log_sim(z_s_D, z_p_D, tau=0.1):
+    ''' Compute log of similarity function
+
+    $$
+    \log \exp \left( z_s \cdot z_p / tau \right)
+    $$
+
+    Returns
+    -------
+    s : float
+    '''
+    return np.inner(z_s_D, z_p_D) / tau
+
+def L_theirs(i, p, pos_ids_P, neg_ids_N, z_BD):
+    ''' Implementation of SupCon loss via Eq 2 of Khosla et al
+
+    See https://arxiv.org/pdf/2004.11362.pdf#page=5
+
+    Uses logsumexp trick for numerical stability
+
+    Returns
+    -------
+    loss : float
+        Value computed at specific S,p indices for current batch
+    '''
+    
+    # Verify the provided indices cover the current batch
+    assert np.allclose(
+        np.sort(np.concatenate(([i, p], pos_ids_P, neg_ids_N))),
+        np.arange(z_BD.shape[0]))
+
+    z_i_D = z_BD[i]
+    z_p_D = z_BD[p]
+    z_pos_PD = z_BD[pos_ids_P]
+    z_neg_ND = z_BD[neg_ids_N]
+
+    log_numer = log_sim(z_i_D, z_p_D)
+    denom_list = [log_numer]
+    for pp in pos_ids_P:
+        denom_list.append(
+            log_sim(z_i_D, z_BD[pp]))
+    for nn in neg_ids_N:
+        denom_list.append(
+            log_sim(z_i_D, z_BD[nn]))
+    log_denom = logsumexp(denom_list)
+    P = 1 + len(pos_ids_P) # divide by number of partners for i
+    return 1/float(P) * (log_numer - log_denom)
+
+def L_ours(S, p, pos_ids_P, neg_ids_N, z_BD):
+    ''' Implementation of SupCon loss via Eq 3 of SINCERE paper
+
+    Returns
+    -------
+    loss : float
+        Value computed at specific S,p indices for current batch
+    '''
+
+    # Verify the provided indices cover the current batch
+    assert np.allclose(
+        np.sort(np.concatenate(([S, p], pos_ids_P, neg_ids_N))),
+        np.arange(z_BD.shape[0]))
+
+    z_s_D = z_BD[S]
+    z_p_D = z_BD[p]
+
+    log_numer = log_sim(z_s_D, z_p_D)
+    denom_list = [log_numer]
+    for pp in pos_ids_P:
+        denom_list.append(
+            log_sim(z_p_D, z_BD[pp]))
+    for nn in neg_ids_N:
+        denom_list.append(
+            log_sim(z_p_D, z_BD[nn]))
+    log_denom = logsumexp(denom_list)
+
+    P = 1 + len(pos_ids_P) # divide by number of partners for S
+    return 1/float(P) * (log_numer - log_denom)
+
+if __name__ == '__main__':
+    B = 6
+    D = 3
+    prng = np.random.RandomState(1)
+
+    z_BD = 0.3 * prng.randn(B, D)
+    z_BD[:B//2] -= 0.2
+    z_BD[B//2:] += 0.2
+
+    y_B = np.zeros(B, dtype=np.int32)
+    y_B[B//2:] += 1
+
+    total_ours = 0.0
+    total_theirs = 0.0
+    for S in range(B):
+        neg_ids_N = np.flatnonzero(y_B != y_B[S])
+
+        partner_ids = np.flatnonzero(y_B == y_B[S]).tolist()
+        partner_ids.remove(S)
+        
+        for p in partner_ids:
+            other_pos_ids_P = copy.deepcopy(partner_ids)
+            other_pos_ids_P.remove(p)
+            loss_ours = L_ours(S, p, other_pos_ids_P, neg_ids_N, z_BD)
+            loss_theirs = L_theirs(p, S, other_pos_ids_P, neg_ids_N, z_BD)
+
+            total_ours += loss_ours
+            total_theirs += loss_theirs
+
+            print("S=%2d p=%2d  | L^ours(S,p) = % .4f  | L^theirs(p, S) =% .4f" % (
+                S, p, loss_ours, loss_theirs))
+
+    print("Total sum over all (S,p) pairs:")
+    print(" % .4f ours " % total_ours)
+    print(" % .4f theirs" % total_theirs)
+
+
+


### PR DESCRIPTION
Added script to sanity check the two different forms of SupCon are equivalent (when summed over all pairs in the dataset). 

Includes both:

* Python script to verify the equivalence
* README with text to help orient a new reader